### PR TITLE
adapter: make FIFOs inferable to BRAM

### DIFF
--- a/adapter/requirements.txt
+++ b/adapter/requirements.txt
@@ -1,21 +1,2 @@
-alabaster==0.7.10
-Babel==2.4.0
-certifi==2017.4.17
-chardet==3.0.4
-colorama==0.3.9
-docutils==0.13.1
-idna==2.5
-imagesize==0.7.1
-Jinja2==2.9.6
-MarkupSafe==1.0
--e git://github.com/m-labs/migen.git@ea55abcad674ba0b76dc1cc8cb1f056770fd5388#egg=migen
-Pygments==2.2.0
-pytz==2017.2
-requests==2.18.1
-six==1.10.0
-snowballstemmer==1.2.1
-Sphinx==1.6.3
-sphinx-rtd-theme==0.2.4
-sphinxcontrib-websupport==1.0.1
-typing==3.6.1
-urllib3==1.21.1
+colorama==0.4.3
+migen==0.9.2

--- a/adapter/top.py
+++ b/adapter/top.py
@@ -29,7 +29,7 @@ __author__ = "Serge 'q3k' Bazanski <serge@bazanski.pl>"
 import sys
 
 from migen import *
-from migen.genlib.fifo import SyncFIFO
+from migen.genlib.fifo import SyncFIFOBuffered
 from migen.build.generic_platform import Subsignal, Pins, IOStandard
 from migen.build.platforms import icestick
 
@@ -78,8 +78,8 @@ class Top(Module):
         ]
 
         # Input/output FIFOs.
-        self.submodules.txbuffer = SyncFIFO(8, 512)
-        self.submodules.rxbuffer = SyncFIFO(8, 512)
+        self.submodules.txbuffer = SyncFIFOBuffered(8, 512)
+        self.submodules.rxbuffer = SyncFIFOBuffered(8, 512)
 
 
         # Dispatch and response flops for host communication.

--- a/adapter/uart.py
+++ b/adapter/uart.py
@@ -24,7 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from migen import Module, Signal, If, FSM, NextState, Cat, NextValue
-from migen.genlib.fifo import SyncFIFO
+from migen.genlib.fifo import SyncFIFOBuffered
 
 class RX(Module):
     def __init__(self, clk_freq, baud_rate):
@@ -92,7 +92,7 @@ class RX(Module):
 class RXFIFO(Module):
     def __init__(self, clk_freq, baud_rate):
         self.submodules.rxcore = RX(clk_freq, baud_rate)
-        self.submodules.fifo = SyncFIFO(8, 1024)
+        self.submodules.fifo = SyncFIFOBuffered(8, 1024)
         self.comb += [
             self.fifo.din.eq(self.rxcore.data)
         ]
@@ -127,7 +127,7 @@ class TXFIFO(Module):
     def __init__(self, clk_freq, baud_rate):
         divisor = clk_freq // baud_rate
 
-        self.submodules.fifo = SyncFIFO(8, 1024)
+        self.submodules.fifo = SyncFIFOBuffered(8, 1024)
         
         self.din = self.fifo.din
         self.we = self.fifo.we
@@ -135,7 +135,7 @@ class TXFIFO(Module):
         self.tx = Signal()
         self.io = { self.din, self.we, self.fifo.writable, self.tx }
 
-        # strobe_counter counts down from divisor to 0, resets automatically
+        # strobe_counter counts down from divisor to 0, resets automatically=
         # or when strobe-start is asserted.
         strobe_counter = Signal(max=divisor)
         strobe_start = Signal()


### PR DESCRIPTION
This counters https://github.com/YosysHQ/yosys/commit/cee4b1e6bc11fff1d2d97985a96e6990afc57950.

@mwkmwkmwk says this should have never worked, so we just swap SyncFIFO for SyncFIFOBuffered and hope for the best.

This has not been tested on hardware, as i don't have a rig or testcases :/.

We also bump migen for good measure.